### PR TITLE
Libraries initiated on request

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 Authors: Mateusz K. Bieniek, Ben Cree, Rachael Pirie, Joshua T. Horton, Natalie J. Tatum, Daniel J. Cole
 
 ** [UNPUBLISHED] version 1.*.***
+ - The user now has to import the libraries (RGroupGrid) and instantiate first.
 
 **version 1.3.0**
 

--- a/fegrow/__init__.py
+++ b/fegrow/__init__.py
@@ -11,11 +11,12 @@ from .package import (
     RLinkerGrid,
     link,
 )
-from .receptor import fix_receptor, optimise_in_receptor, sort_conformers
+from .receptor import (
+    fix_receptor,
+    optimise_in_receptor,
+    sort_conformers
+)
 from .toxicity import tox_props
-
-RGroups = RGroupGrid()
-RLinkers = RLinkerGrid()
 
 # get the version
 __version__ = open(Path(__file__).parent / "version.txt").read().strip()
@@ -28,8 +29,8 @@ __all__ = [
     optimise_in_receptor,
     tox_props,
     sort_conformers,
-    RGroups,
-    RLinkers,
+    RGroupGrid,
+    RLinkerGrid,
     link,
     build_molecules,
     ic50,

--- a/fegrow/testing/test_general.py
+++ b/fegrow/testing/test_general.py
@@ -2,7 +2,12 @@ import pathlib
 
 from rdkit import Chem
 import fegrow
-from fegrow import RGroups, RLinkers
+from fegrow import RGroupGrid, RLinkerGrid
+
+
+# instantiate the libraries
+RGroups = RGroupGrid()
+RLinkers = RLinkerGrid()
 
 root = pathlib.Path(__file__).parent
 

--- a/notebooks/.tutorial.py
+++ b/notebooks/.tutorial.py
@@ -28,7 +28,10 @@ import prody
 from rdkit import Chem
 
 import fegrow
-from fegrow import RGroups, RLinkers
+from fegrow import RGroupGrid, RLinkerGrid
+
+RGroups = RGroupGrid()
+RLinkers = RLinkerGrid()
 
 
 # # Prepare the ligand template

--- a/notebooks/tutorial.ipynb
+++ b/notebooks/tutorial.ipynb
@@ -43,7 +43,11 @@
     "from rdkit import Chem\n",
     "\n",
     "import fegrow\n",
-    "from fegrow import RGroups, RLinkers"
+    "from fegrow import RGroupGrid, RLinkerGrid\n",
+    "\n",
+    "# Initialise libraries\n",
+    "RGroups = RGroupGrid()\n",
+    "RLinkers = RLinkerGrid()"
    ]
   },
   {
@@ -607,7 +611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The libraries cannot always be initiated or loaded into rmolgrid on our cluster "rocket". Here we avoid the issue and still provide a function from which we can get the dataframe with rgroups. 

The side effect is that there very little extra work for the user to import and initiate the library. 