### PR TITLE
Builder: growing not just from hydrogens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Authors: Mateusz K. Bieniek, Ben Cree, Rachael Pirie, Joshua T. Horton, Natalie 
  - ANI in some cases explodes. Remove the bad conformers with bonds that have lengths larger than 3A.
  - The user now has to import the libraries (RGroupGrid) and instantiate first.
  - Libraries (linkers, rgroups) are now single .sdf files to avoid problems on clusters with many small files
+ - A growing vector can now be any molecule-separating atom in the molecule.
 
 **version 1.3.0**
 

--- a/fegrow/__init__.py
+++ b/fegrow/__init__.py
@@ -6,10 +6,8 @@ from .package import (
     RMol,
     rep2D,
     build_molecules,
-    ic50,
     RGroupGrid,
     RLinkerGrid,
-    link,
 )
 from .receptor import (
     fix_receptor,
@@ -31,9 +29,7 @@ __all__ = [
     sort_conformers,
     RGroupGrid,
     RLinkerGrid,
-    link,
     build_molecules,
-    ic50,
     __version__,
     WrongCoreForMolecule
 ]

--- a/fegrow/__init__.py
+++ b/fegrow/__init__.py
@@ -9,11 +9,7 @@ from .package import (
     RGroupGrid,
     RLinkerGrid,
 )
-from .receptor import (
-    fix_receptor,
-    optimise_in_receptor,
-    sort_conformers
-)
+from .receptor import fix_receptor, optimise_in_receptor, sort_conformers
 from .toxicity import tox_props
 
 # get the version
@@ -31,5 +27,5 @@ __all__ = [
     RLinkerGrid,
     build_molecules,
     __version__,
-    WrongCoreForMolecule
+    WrongCoreForMolecule,
 ]

--- a/fegrow/builder.py
+++ b/fegrow/builder.py
@@ -1,0 +1,197 @@
+import copy
+from typing import List, Optional, Union
+
+from rdkit import Chem
+from rdkit.Chem.rdMolAlign import AlignMol
+
+
+def build_molecules_with_rdkit(
+    templates: Union[Chem.Mol, List[Chem.Mol]],
+    r_groups: Union[Chem.Mol, List[Chem.Mol], int],
+    attachment_points: Optional[List[int]] = None,
+):
+    """
+    For the given core molecule and list of attachment points
+     and r groups enumerate the possible molecules and
+     return a list of them.
+
+    :param template: The core scaffold molecule to attach the r groups to, or a list of them.
+    :param r_group: The list of rdkit molecules which should be considered
+      r groups or the RGroup Grid with highlighted molecules.
+    :param attachment_points: The list of atom index in the core ligand
+      that the r groups should be attached to. If it is empty, connecting points are sought out and matched.
+    """
+
+    # fixme - special case after changing the API: remove in the future
+    # This is a temporary warning about the change in the interface.
+    # This change is because there are situations where the attachment_points do not need to be passed to the function.
+    if (
+        isinstance(r_groups, list)
+        and len(r_groups) > 0
+        and isinstance(r_groups[0], int)
+    ):
+        print(
+            'Warning: second argument is detected to be an integer. It is now "r_groups" '
+            "whereas attachement_points are provided as the 3rd argument. "
+        )
+        raise Exception(
+            "Please note that after adding the linker to FEgrow (version 1.1), "
+            'the "build_molecules" function interface has changed to'
+            ' "build_molecules(core_ligand, r_groups, attachment_points)". '
+        )
+
+    # ensure template and r_group are lists
+    if not issubclass(templates.__class__, List):
+        templates = [templates]
+    if not issubclass(r_groups.__class__, List):
+        r_groups = [r_groups]
+
+    # make a deep copy of r_groups/linkers to ensure we don't modify the library
+    templates = [copy.deepcopy(mol) for mol in templates]
+    r_groups = [copy.deepcopy(mol) for mol in r_groups]
+
+    # get attachment points for each template
+    if not attachment_points:
+        # attempt to generate the attachment points by picking the joining molecule
+        # case: a list of templates previously joined with linkers requires iterating over them
+        attachment_points = [__getAttachmentVector(lig)[0].GetIdx() for lig in templates]
+
+    if not attachment_points:
+        raise Exception("Could not find attachement points. ")
+
+    if len(attachment_points) != len(templates):
+        raise Exception(
+            f"There must be one attachment point for each template. "
+            f"Provided attachement points = {len(attachment_points)} "
+            f"with templates number: {len(templates)}"
+        )
+
+    combined_mols = []
+    id_counter = 0
+    for atom_idx, scaffold_ligand in zip(attachment_points, templates):
+        for r_mol in r_groups:
+            scaffold_mol = copy.deepcopy(scaffold_ligand)
+            merged_mol, scaffold_no_attachement = merge_R_group(
+                scaffold=scaffold_mol, RGroup=r_mol, replace_index=atom_idx
+            )
+            # assign the identifying index to the molecule
+            merged_mol.id = id_counter
+            combined_mols.append((merged_mol, scaffold_no_attachement))
+            id_counter += 1
+
+    return combined_mols
+
+
+def merge_R_group(scaffold, RGroup, replace_index):
+    """function originally copied from
+    https://github.com/molecularsets/moses/blob/master/moses/baselines/combinatorial.py
+    """
+
+    # the linking R atom on the R group
+    # fixme: attempt to do the same on the template if replace index is not provided
+    rgroup_R_atom, R_atom_neighbour = __getAttachmentVector(RGroup)
+
+    # atom to be replaced in the scaffold
+    atom_to_replace = scaffold.GetAtomWithIdx(replace_index)
+    if len(atom_to_replace.GetNeighbors()) != 1:
+        raise NotImplementedError(f"The atom being replaced (ID={atom_to_replace.GetIdx()}, Element={atom_to_replace.GetAtomicNum()}) "
+                        f"on the molecule has more neighbour atoms than 1. Not supported.")
+
+    hook = atom_to_replace.GetNeighbors()[0]
+
+    # align the Rgroup
+    AlignMol(
+        RGroup,
+        scaffold,
+        atomMap=(
+            (R_atom_neighbour.GetIdx(), atom_to_replace.GetIdx()),
+            (rgroup_R_atom.GetIdx(), hook.GetIdx()),
+        ),
+    )
+
+    # merge
+    combined = Chem.CombineMols(scaffold, RGroup)
+    emol = Chem.EditableMol(combined)
+
+    # connect
+    bond_order = rgroup_R_atom.GetBonds()[0].GetBondType()
+    emol.AddBond(
+        hook.GetIdx(),
+        R_atom_neighbour.GetIdx() + scaffold.GetNumAtoms(),
+        order=bond_order,
+    )
+    # -1 accounts for the removed linking atom on the template
+    emol.RemoveAtom(rgroup_R_atom.GetIdx() + scaffold.GetNumAtoms())
+    # remove the linking atom on the template
+    emol.RemoveAtom(atom_to_replace.GetIdx())
+
+    merged = emol.GetMol()
+    Chem.SanitizeMol(merged)
+
+    # use only the best/first conformer
+    for c in list(merged.GetConformers())[1:]:
+        merged.RemoveConformer(c.GetId())
+
+    # bookkeeping about scaffolding
+    etemp = Chem.EditableMol(scaffold)
+    etemp.RemoveAtom(atom_to_replace.GetIdx())
+    scaffold_no_attachement = etemp.GetMol()
+
+    if is_linker(RGroup):
+        # update the linker so that there is an attachment point left for the future
+        # atom in the linker with a label=1 was used for the merging
+        # rename label=2 to 0 to turn it into a simple R-group
+        for atom in merged.GetAtoms():
+            if atom.GetAtomMapNum() == 2:
+                atom.SetAtomMapNum(0)
+
+    return merged, scaffold_no_attachement
+
+
+def __getAttachmentVector(R_group):
+    """In the R-group or a linker, search for the position of the attachment point (R atom)
+    and extract the atom (currently only single bond supported). In case of the linker,
+    the R1 atom is selected.
+    rgroup: fragment passed as rdkit molecule
+    return: tuple (ratom, ratom_neighbour)
+    """
+
+    # find the R groups in the molecule
+    ratoms = [atom for atom in R_group.GetAtoms() if atom.GetAtomicNum() == 0]
+    if not len(ratoms):
+        raise Exception(
+            "The R-group does not have R-atoms (Atoms with index == 0, visualised with a '*' character)"
+        )
+
+    # if it is a linker, it will have more than 1 R group, pick the one with index 1
+    if len(ratoms) == 1:
+        atom = ratoms[0]
+    elif is_linker(R_group):
+        # find the attachable point
+        ratoms = [atom for atom in ratoms if atom.GetAtomMapNum() == 1]
+        atom = ratoms[0]
+    else:
+        raise Exception(
+            "Either missing R-atoms, or more than two R-atoms. "
+            '"Atom.GetAtomicNum" should be 0 for the R-atoms, and in the case of the linker,  '
+            '"Atom.GetAtomMapNum" has to specify the order (1,2) '
+        )
+
+    neighbours = atom.GetNeighbors()
+    if len(neighbours) > 1:
+        raise NotImplementedError(
+            "The linking R atom in the R group has two or more attachment points. "
+        )
+
+    return atom, neighbours[0]
+
+
+
+def is_linker(rmol):
+    """
+    Check if the molecule is a linker by checking if it has 2 R-group points
+    """
+    if len([atom for atom in rmol.GetAtoms() if atom.GetAtomMapNum() in (1, 2)]) == 2:
+        return True
+
+    return False

--- a/fegrow/builder.py
+++ b/fegrow/builder.py
@@ -54,7 +54,7 @@ def build_molecules_with_rdkit(
     if not attachment_points:
         # attempt to generate the attachment points by picking the joining molecule
         # case: a list of templates previously joined with linkers requires iterating over them
-        attachment_points = [__getAttachmentVector(lig)[0].GetIdx() for lig in templates]
+        attachment_points = [get_attachment_vector(lig)[0].GetIdx() for lig in templates]
 
     if not attachment_points:
         raise Exception("Could not find attachement points. ")
@@ -89,7 +89,7 @@ def merge_R_group(scaffold, RGroup, replace_index):
 
     # the linking R atom on the R group
     # fixme: attempt to do the same on the template if replace index is not provided
-    rgroup_R_atom, R_atom_neighbour = __getAttachmentVector(RGroup)
+    rgroup_R_atom, R_atom_neighbour = get_attachment_vector(RGroup)
 
     # atom to be replaced in the scaffold
     atom_to_replace = scaffold.GetAtomWithIdx(replace_index)
@@ -148,7 +148,7 @@ def merge_R_group(scaffold, RGroup, replace_index):
     return merged, scaffold_no_attachement
 
 
-def __getAttachmentVector(R_group):
+def get_attachment_vector(R_group):
     """In the R-group or a linker, search for the position of the attachment point (R atom)
     and extract the atom (currently only single bond supported). In case of the linker,
     the R1 atom is selected.

--- a/fegrow/builder.py
+++ b/fegrow/builder.py
@@ -10,6 +10,7 @@ from rdkit.Chem.rdMolAlign import AlignMol
 
 logger = logging.getLogger(__name__)
 
+
 def build_molecules_with_rdkit(
     templates: Union[Chem.Mol, List[Chem.Mol]],
     r_groups: Union[Chem.Mol, List[Chem.Mol], int],
@@ -63,7 +64,9 @@ def build_molecules_with_rdkit(
     if not attachment_points:
         # attempt to generate the attachment points by picking the joining molecule
         # case: a list of templates previously joined with linkers requires iterating over them
-        attachment_points = [get_attachment_vector(lig)[0].GetIdx() for lig in templates]
+        attachment_points = [
+            get_attachment_vector(lig)[0].GetIdx() for lig in templates
+        ]
 
     if not attachment_points:
         raise Exception("Could not find attachement points. ")
@@ -77,12 +80,16 @@ def build_molecules_with_rdkit(
 
     combined_mols = []
     id_counter = 0
-    for atom_idx, scaffold_ligand, keep_submolecule_cue in \
-            itertools.zip_longest(attachment_points, templates, keep_components, fillvalue=None):
+    for atom_idx, scaffold_ligand, keep_submolecule_cue in itertools.zip_longest(
+        attachment_points, templates, keep_components, fillvalue=None
+    ):
         for r_mol in r_groups:
             scaffold_mol = copy.deepcopy(scaffold_ligand)
             merged_mol, scaffold_no_attachement = merge_R_group(
-                scaffold=scaffold_mol, RGroup=r_mol, replace_index=atom_idx, keep_cue_idx=keep_submolecule_cue
+                scaffold=scaffold_mol,
+                RGroup=r_mol,
+                replace_index=atom_idx,
+                keep_cue_idx=keep_submolecule_cue,
             )
             # assign the identifying index to the molecule
             merged_mol.id = id_counter
@@ -107,8 +114,10 @@ def split(molecule, splitting_atom, keep_neighbour_idx=None):
 
     connected_components = list(networkx.connected_components(G))
     if len(connected_components) != 2:
-        raise ValueError(f'The molecule is not divided into two separate components '
-                        f'with the Atom ID={splitting_atom.GetIdx()}, so we cannot decide which component to remove. ')
+        raise ValueError(
+            f"The molecule is not divided into two separate components "
+            f"with the Atom ID={splitting_atom.GetIdx()}, so we cannot decide which component to remove. "
+        )
 
     if keep_neighbour_idx in connected_components[1]:
         atom_ids_for_removal = connected_components[0]
@@ -117,11 +126,15 @@ def split(molecule, splitting_atom, keep_neighbour_idx=None):
     else:
         # keep the larger side of the molecule
         if len(connected_components[0]) == len(connected_components[1]):
-            raise ValueError(f'The molecule has two equally sized separated components, '
-                             f'and it is not clear which one to keep, please use "keep_neighbour_idx" '
-                             f'to mark the size of the molecule that should be used as the scaffold.')
+            raise ValueError(
+                f"The molecule has two equally sized separated components, "
+                f'and it is not clear which one to keep, please use "keep_neighbour_idx" '
+                f"to mark the size of the molecule that should be used as the scaffold."
+            )
 
-        logger.info('User has not selected manually which side of the molecule to keep. Selecting the larger side. ')
+        logger.info(
+            "User has not selected manually which side of the molecule to keep. Selecting the larger side. "
+        )
         atom_ids_for_removal, _ = sorted(connected_components, key=len)
 
     # remove the unwanted component
@@ -130,14 +143,22 @@ def split(molecule, splitting_atom, keep_neighbour_idx=None):
         edit_scaffold.RemoveAtom(idx)
     scaffold = edit_scaffold.GetMol()
 
-    kept_atoms = [a for a in molecule.GetAtoms() if a.GetIdx() not in atom_ids_for_removal]
+    kept_atoms = [
+        a for a in molecule.GetAtoms() if a.GetIdx() not in atom_ids_for_removal
+    ]
     scaffold_elements = [a for a in scaffold.GetAtoms()]
 
     # removing atoms changes the IDs of the atoms that remain
-    if [a.GetAtomicNum() for a in kept_atoms] != [a.GetAtomicNum() for a in scaffold_elements]:
-        raise Exception('The assumption that the modified molecule will keep the atoms in the same order is false. '
-                        'Please get in touch with the FEgrow maintainers. ')
-    idx_map = dict(zip([a.GetIdx() for a in kept_atoms], [a.GetIdx() for a in scaffold_elements]))
+    if [a.GetAtomicNum() for a in kept_atoms] != [
+        a.GetAtomicNum() for a in scaffold_elements
+    ]:
+        raise Exception(
+            "The assumption that the modified molecule will keep the atoms in the same order is false. "
+            "Please get in touch with the FEgrow maintainers. "
+        )
+    idx_map = dict(
+        zip([a.GetIdx() for a in kept_atoms], [a.GetIdx() for a in scaffold_elements])
+    )
     return scaffold, idx_map
 
 
@@ -247,7 +268,6 @@ def get_attachment_vector(R_group):
         )
 
     return atom, neighbours[0]
-
 
 
 def is_linker(rmol):

--- a/fegrow/conformers.py
+++ b/fegrow/conformers.py
@@ -8,8 +8,10 @@ from rdkit.Chem import AllChem
 
 logger = logging.getLogger(__name__)
 
+
 class WrongCoreForMolecule(Exception):
     pass
+
 
 def duplicate_conformers(
     m: Chem.rdchem.Mol, new_conf_idx: int, rms_limit: float = 0.5
@@ -81,7 +83,9 @@ def generate_conformers(
                 rmol.RemoveConformer(conf_idx)
 
     if dup_count:
-        logger.debug(f"Removed {dup_count} duplicated conformations, leaving {rmol.GetNumConformers()} in total. ")
+        logger.debug(
+            f"Removed {dup_count} duplicated conformations, leaving {rmol.GetNumConformers()} in total. "
+        )
 
     return rmol
 

--- a/fegrow/package.py
+++ b/fegrow/package.py
@@ -1,25 +1,25 @@
-import logging
+import abc
 import copy
-import stat
-from typing import Optional, List, Union
+import logging
 import os
-import tempfile
-import subprocess
-import re
 from pathlib import Path
-from urllib.request import urlretrieve
+import re
+import stat
+import subprocess
+import tempfile
+from typing import List, Optional, Union
+import urllib
 
 import numpy as np
-from prody.proteins.functions import view3D
+import mols2grid
+import pandas
+import prody
 import py3Dmol
 import rdkit
 from rdkit import Chem
-from rdkit.Chem import AllChem, Draw
-from rdkit.Chem.rdMolAlign import AlignMol
-from rdkit.Chem import PandasTools
-import mols2grid
-import pandas
+from rdkit.Chem import AllChem, Draw, PandasTools
 
+from .builder import build_molecules_with_rdkit
 from .conformers import generate_conformers
 from .toxicity import tox_props
 
@@ -29,184 +29,33 @@ pandas.set_option('display.precision', 3)
 logger = logging.getLogger(__name__)
 
 
-def replace_atom(mol: Chem.Mol, target_idx: int, new_atom: int) -> Chem.Mol:
-    edit_mol = Chem.RWMol(mol)
-    for atom in edit_mol.GetAtoms():
-        if atom.GetIdx() == target_idx:
-            atom.SetAtomicNum(new_atom)
-    return Chem.Mol(edit_mol)
-
-
-def rep2D(mol, idx=-1, rdkit_mol=False, **kwargs):
-    numbered = copy.deepcopy(mol)
-    numbered.RemoveAllConformers()
-    if idx:
-        for atom in numbered.GetAtoms():
-            atom.SetAtomMapNum(atom.GetIdx())
-    AllChem.Compute2DCoords(numbered)
-
-    if rdkit_mol:
-        return numbered
-    else:
-        return Draw.MolToImage(numbered, **kwargs)
-
-
-def rep3D(mol):
-    viewer = py3Dmol.view(width=300, height=300, viewergrid=(1, 1))
-    for i in range(mol.GetNumConformers()):
-        mb = Chem.MolToMolBlock(mol, confId=i)
-        viewer.addModel(mb, "mol")
-    viewer.setStyle({"stick": {}})
-    viewer.zoomTo()
-    return viewer
-
-
-def is_linker(rmol):
-    """
-    Check if the molecule is a linker by checking if it has 2 R-group points
-    """
-    if len([atom for atom in rmol.GetAtoms() if atom.GetAtomMapNum() in (1, 2)]) == 2:
-        return True
-
-    return False
-
-
-def __getAttachmentVector(R_group):
-    """In the R-group or a linker, search for the position of the attachment point (R atom)
-    and extract the atom (currently only single bond supported). In case of the linker,
-    the R1 atom is selected.
-    rgroup: fragment passed as rdkit molecule
-    return: tuple (ratom, ratom_neighbour)
-    """
-
-    # find the R groups in the molecule
-    ratoms = [atom for atom in R_group.GetAtoms() if atom.GetAtomicNum() == 0]
-    if not len(ratoms):
-        raise Exception(
-            "The R-group does not have R-atoms (Atoms with index == 0, visualised with a '*' character)"
-        )
-
-    # if it is a linker, it will have more than 1 R group, pick the one with index 1
-    if len(ratoms) == 1:
-        atom = ratoms[0]
-    elif is_linker(R_group):
-        # find the attachable point
-        ratoms = [atom for atom in ratoms if atom.GetAtomMapNum() == 1]
-        atom = ratoms[0]
-    else:
-        raise Exception(
-            "Either missing R-atoms, or more than two R-atoms. "
-            '"Atom.GetAtomicNum" should be 0 for the R-atoms, and in the case of the linker,  '
-            '"Atom.GetAtomMapNum" has to specify the order (1,2) '
-        )
-
-    neighbours = atom.GetNeighbors()
-    if len(neighbours) > 1:
-        raise NotImplementedError(
-            "The linking R atom in the R group has two or more attachment points. "
-        )
-
-    return atom, neighbours[0]
-
-
-def merge_R_group(scaffold, RGroup, replace_index):
-    """function originally copied from
-    https://github.com/molecularsets/moses/blob/master/moses/baselines/combinatorial.py
-    """
-
-    # the linking R atom on the R group
-    # fixme: attempt to do the same on the template if replace index is not provided
-    rgroup_R_atom, R_atom_neighbour = __getAttachmentVector(RGroup)
-
-    # atom to be replaced in the scaffold
-    atom_to_replace = scaffold.GetAtomWithIdx(replace_index)
-    if len(atom_to_replace.GetNeighbors()) != 1:
-        raise NotImplementedError(f"The atom being replaced (ID={atom_to_replace.GetIdx()}, Element={atom_to_replace.GetAtomicNum()}) "
-                        f"on the molecule has more neighbour atoms than 1. Not supported.")
-
-    hook = atom_to_replace.GetNeighbors()[0]
-
-    # align the Rgroup
-    AlignMol(
-        RGroup,
-        scaffold,
-        atomMap=(
-            (R_atom_neighbour.GetIdx(), atom_to_replace.GetIdx()),
-            (rgroup_R_atom.GetIdx(), hook.GetIdx()),
-        ),
-    )
-
-    # merge
-    combined = Chem.CombineMols(scaffold, RGroup)
-    emol = Chem.EditableMol(combined)
-
-    # connect
-    bond_order = rgroup_R_atom.GetBonds()[0].GetBondType()
-    emol.AddBond(
-        hook.GetIdx(),
-        R_atom_neighbour.GetIdx() + scaffold.GetNumAtoms(),
-        order=bond_order,
-    )
-    # -1 accounts for the removed linking atom on the template
-    emol.RemoveAtom(rgroup_R_atom.GetIdx() + scaffold.GetNumAtoms())
-    # remove the linking atom on the template
-    emol.RemoveAtom(atom_to_replace.GetIdx())
-
-    merged = emol.GetMol()
-    Chem.SanitizeMol(merged)
-
-    # use only the best/first conformer
-    for c in list(merged.GetConformers())[1:]:
-        merged.RemoveConformer(c.GetId())
-
-    # bookkeeping about scaffolding
-    etemp = Chem.EditableMol(scaffold)
-    etemp.RemoveAtom(atom_to_replace.GetIdx())
-    template = etemp.GetMol()
-
-    with_template = RMol(merged)
-    with_template._save_template(template)
-    # save the group
-    with_template._save_rgroup(RGroup)
-
-    if is_linker(RGroup):
-        # update the linker so that there is an attachment point left for the future
-        # atom in the linker with a label=1 was used for the merging
-        # rename label=2 to 0 to turn it into a simple R-group
-        for atom in with_template.GetAtoms():
-            if atom.GetAtomMapNum() == 2:
-                atom.SetAtomMapNum(0)
-
-    return with_template
-
-
-def ic50(x):
-    return 10 ** (-x - -9)
-
-
-class RInterface:
+class RInterface():
     """
     This is a shared interface for a molecule and a list of molecules.
 
     The main purpose is to allow using the same functions on a single molecule and on a group of them.
     """
 
+    @abc.abstractmethod
     def rep2D(self, **kwargs):
-        pass
+        ...
 
+    @abc.abstractmethod
     def toxicity(self):
         pass
 
+    @abc.abstractmethod
     def generate_conformers(
         self, num_conf: int, minimum_conf_rms: Optional[float] = [], **kwargs
     ):
         pass
 
+    @abc.abstractmethod
     def remove_clashing_confs(self, prot, min_dst_allowed=1):
         pass
 
 
-class RMol(rdkit.Chem.rdchem.Mol, RInterface):
+class RMol(RInterface, rdkit.Chem.rdchem.Mol):
     """
     RMol is essentially a wrapper around RDKit Mol with
     tailored functionalities for attaching R groups, etc.
@@ -237,9 +86,6 @@ class RMol(rdkit.Chem.rdchem.Mol, RInterface):
 
     def _save_template(self, mol):
         self.template = RMol(copy.deepcopy(mol))
-
-    def _save_rgroup(self, rgroup):
-        self.rgroup = rgroup
 
     def _save_opt_energies(self, energies):
         self.opt_energies = energies
@@ -381,7 +227,7 @@ class RMol(rdkit.Chem.rdchem.Mol, RInterface):
         return rep2D(self, **kwargs)
 
     def rep3D(
-        self, view=None, prody=None, template=False, confIds: Optional[List[int]] = None
+        self, view=None, prody_protein=None, template=False, confIds: Optional[List[int]] = None
     ):
         """
         Use py3Dmol to obtain the 3D view of the molecule.
@@ -391,15 +237,15 @@ class RMol(rdkit.Chem.rdchem.Mol, RInterface):
         :param view: a view to which add the visualisation. Useful if one wants to 3D view
             multiple conformers in one view.
         :type view: py3Dmol view instance (None)
-        :param prody: A prody protein around which a view 3D can be created
+        :param prody_protein: A prody protein around which a view 3D can be created
         :type prody: Prody instance (Default: None)
         :param template: Whether to visualise the original 3D template as well from which the molecule was made.
         :type template: bool (False)
         :param confIds: Select the conformations for display.
         :type confIds: List[int]
         """
-        if prody is not None:
-            view = view3D(prody)
+        if prody_protein is not None:
+            view = prody.proteins.functions.view3D(prody_protein)
 
         if view is None:
             view = py3Dmol.view(width=400, height=400, viewergrid=(1, 1))
@@ -498,7 +344,7 @@ class RMol(rdkit.Chem.rdchem.Mol, RInterface):
         print(f"Gnina not found or set. Download gnina (~500MB) into {RMol.gnina_dir}")
         gnina = os.path.join(RMol.gnina_dir, "gnina")
         # fixme - currently download to the working directory (Home could be more applicable).
-        urlretrieve(
+        urllib.request.urlretrieve(
             "https://github.com/gnina/gnina/releases/download/v1.0.1/gnina",
             filename=gnina,
         )
@@ -553,6 +399,9 @@ class RMol(rdkit.Chem.rdchem.Mol, RInterface):
 
         # convert to floats
         CNNaffinities = list(map(float, CNNaffinities_str))
+
+        def ic50(x):
+            return 10 ** (-x - -9)
 
         # generate IC50 from the CNNaffinities
         ic50s = list(map(ic50, CNNaffinities))
@@ -635,138 +484,6 @@ class RMol(rdkit.Chem.rdchem.Mol, RInterface):
         return df._repr_html_()
 
 
-class RGroupGrid(mols2grid.MolGrid):
-    """
-    A wrapper around the mols to grid class to load and process the r group folders locally.
-    """
-
-    def __init__(self):
-        dataframe = RGroupGrid._load_molecules()
-
-        super(RGroupGrid, self).__init__(
-            dataframe, removeHs=True, mol_col="Mol", use_coords=False, name="m2"
-        )
-
-    @staticmethod
-    def _load_molecules() -> pandas.DataFrame:
-        """
-        Load the local r groups into rdkit molecules
-        """
-        molecules = []
-        names = []
-
-        builtin_rgroups = Path(__file__).parent / "data" / "rgroups" / "library.sdf"
-        for rgroup in Chem.SDMolSupplier(str(builtin_rgroups), removeHs=False):
-            molecules.append(rgroup)
-            names.append(rgroup.GetProp('SMILES'))
-
-            # highlight the attachment atom
-            for atom in rgroup.GetAtoms():
-                if atom.GetAtomicNum() == 0:
-                    setattr(rgroup, "__sssAtoms", [atom.GetIdx()])
-
-        return pandas.DataFrame({"Mol": molecules, "Name": names})
-
-    def _ipython_display_(self):
-        from IPython.display import display, update_display, display_html
-
-        subset = ["img", "Name", "mols2grid-id"]
-        display_html(self.display(subset=subset, substruct_highlight=True))
-
-    def get_selected(self):
-        # use the new API
-        df = self.get_selection()
-        # now get a list of the molecules
-        return list(df["Mol"])
-
-
-class RLinkerGrid(mols2grid.MolGrid):
-    """
-    A wrapper around the mols to grid class to load and process the linker folders locally.
-    """
-
-    def __init__(self):
-        dataframe = RLinkerGrid._load_molecules()
-
-        super(RLinkerGrid, self).__init__(
-            dataframe,
-            removeHs=True,
-            mol_col="Mol",
-            use_coords=False,
-            name="m1",
-            prerender=False,
-        )
-
-    @staticmethod
-    def _load_molecules() -> pandas.DataFrame:
-        """
-        Load the local linkers into rdkit molecules
-        """
-
-        # note that the linkers are pre-sorted so that:
-        #  - [R1]C[R2] is next to [R2]C[R1]
-        #  - according to how common they are (See the original publication) as described with SmileIndex
-        builtin_rlinkers = Path(__file__).parent / "data" / "linkers" / "library.sdf"
-
-        linkers = []
-        for mol in Chem.SDMolSupplier(str(builtin_rlinkers), removeHs=False):
-            # use easier searchable SMILES, e.g. [*:1] was replaced with R1
-            display_name = mol.GetProp('display_smiles')
-
-            # extract the index property from the original publication
-            smile_index = mol.GetIntProp("SmileIndex")
-
-            linkers.append([mol, display_name, smile_index])
-
-        return pandas.DataFrame(linkers, columns=['Mol', 'Name', 'Common'])
-
-    def _ipython_display_(self):
-        from IPython.display import display
-
-        subset = ["img", "Name", "mols2grid-id"]
-        return display(self.display(subset=subset, substruct_highlight=True))
-
-    def get_selected(self):
-        # use the new API
-        df = self.get_selection()
-        # now get a list of the molecules
-        return list(df["Mol"])
-
-
-def link(Rgroups, Rlinkers, One2One=False):
-    """
-
-    :param Rgroups:
-    :param Rlinkers:
-    :param One2One: If True, for each selected RGroup, a selected linker with the same index is added.
-        Alternatively, each linker is added to each RGroup resulting in n x m number of combinsions, with n being
-        the number of RGroups and m the number of linkers.
-    :return:
-    """
-
-    # convert rgroups/linkers to smiles
-    rgroup_smiles = [Chem.MolToSmiles(mol) for mol in Rgroups]
-    linker_smiles = [Chem.MolToSmiles(mol) for mol in Rlinkers]
-
-    # loop over and combine smiles
-    combined = []
-    if One2One:
-        for linker, rgroup in zip(linker_smiles, rgroup_smiles):
-            combined.append(rgroup.replace("*", "*" + linker))
-    else:
-        for linker in linker_smiles:
-            for rgroup in rgroup_smiles:
-                combined.append(rgroup.replace("*", "*" + linker))
-
-    # generate 3D conformers for each molecule
-    mols = []
-    for smile in combined:
-        mol = Chem.MolFromSmiles(smile)
-        AllChem.EmbedMultipleConfs(mol, numConfs=1, params=AllChem.ETKDGv3())
-        mols.append(mol)
-    return mols
-
-
 class RList(RInterface, list):
     """
     Streamline working with RMol by presenting the same interface on the list,
@@ -784,7 +501,7 @@ class RList(RInterface, list):
             return
 
         # add a column with the visualisation
-        PandasTools.AddMoleculeColumnToFrame(
+        Chem.PandasTools.AddMoleculeColumnToFrame(
             df, "Smiles", "Molecule", includeFingerprints=True
         )
 
@@ -869,78 +586,132 @@ class RList(RInterface, list):
         return df._repr_html_()
 
 
+class RGroupGrid(mols2grid.MolGrid):
+    """
+    A wrapper around the mols to grid class to load and process the r group folders locally.
+    """
+
+    def __init__(self):
+        dataframe = RGroupGrid._load_molecules()
+
+        super(RGroupGrid, self).__init__(
+            dataframe, removeHs=True, mol_col="Mol", use_coords=False, name="m2"
+        )
+
+    @staticmethod
+    def _load_molecules() -> pandas.DataFrame:
+        """
+        Load the library RGroups
+        """
+        molecules = []
+        names = []
+
+        builtin_rgroups = Path(__file__).parent / "data" / "rgroups" / "library.sdf"
+        for rgroup in Chem.SDMolSupplier(str(builtin_rgroups), removeHs=False):
+            molecules.append(rgroup)
+            names.append(rgroup.GetProp('SMILES'))
+
+            # highlight the attachment atom
+            for atom in rgroup.GetAtoms():
+                if atom.GetAtomicNum() == 0:
+                    setattr(rgroup, "__sssAtoms", [atom.GetIdx()])
+
+        return pandas.DataFrame({"Mol": molecules, "Name": names})
+
+    def _ipython_display_(self):
+        from IPython.display import display_html
+        subset = ["img", "Name", "mols2grid-id"]
+        display_html(self.display(subset=subset, substruct_highlight=True))
+
+    def get_selected(self):
+        df = self.get_selection()
+        return list(df["Mol"])
+
+
+class RLinkerGrid(mols2grid.MolGrid):
+    """
+    A wrapper around the mols to grid class to load and process the linker folders locally.
+    """
+
+    def __init__(self):
+        dataframe = RLinkerGrid._load_molecules()
+
+        super(RLinkerGrid, self).__init__(
+            dataframe,
+            removeHs=True,
+            mol_col="Mol",
+            use_coords=False,
+            name="m1",
+            prerender=False,
+        )
+
+    @staticmethod
+    def _load_molecules() -> pandas.DataFrame:
+        """
+        Load the library linkers
+        """
+
+        # note that the linkers are pre-sorted so that:
+        #  - [R1]C[R2] is next to [R2]C[R1]
+        #  - according to how common they are (See the original publication) as described with SmileIndex
+        builtin_rlinkers = Path(__file__).parent / "data" / "linkers" / "library.sdf"
+
+        linkers = []
+        for mol in Chem.SDMolSupplier(str(builtin_rlinkers), removeHs=False):
+            # use easier searchable SMILES, e.g. [*:1] was replaced with R1
+            display_name = mol.GetProp('display_smiles')
+
+            # extract the index property from the original publication
+            smile_index = mol.GetIntProp("SmileIndex")
+
+            linkers.append([mol, display_name, smile_index])
+
+        return pandas.DataFrame(linkers, columns=['Mol', 'Name', 'Common'])
+
+    def _ipython_display_(self):
+        from IPython.display import display
+        subset = ["img", "Name", "mols2grid-id"]
+        return display(self.display(subset=subset, substruct_highlight=True))
+
+    def get_selected(self):
+        df = self.get_selection()
+        return list(df["Mol"])
+
+
 def build_molecules(
-    templates: Union[Chem.Mol, List[Chem.Mol]],
-    r_groups: Union[Chem.Mol, List[Chem.Mol], int],
-    attachment_points: Optional[List[int]] = None,
+        templates: Union[Chem.Mol, List[Chem.Mol]],
+        r_groups: Union[Chem.Mol, List[Chem.Mol], int],
+        attachment_points: Optional[List[int]] = None,
 ):
-    """
-    For the given core molecule and list of attachment points
-     and r groups enumerate the possible molecules and
-     return a list of them.
+    built_mols = build_molecules_with_rdkit(templates, r_groups, attachment_points)
+    rlist = RList()
+    for mol, scaffold_no_attachement in built_mols:
+        rmol = RMol(mol)
+        rmol._save_template(scaffold_no_attachement)
+        rlist.append(rmol)
 
-    :param template: The core scaffold molecule to attach the r groups to, or a list of them.
-    :param r_group: The list of rdkit molecules which should be considered
-      r groups or the RGroup Grid with highlighted molecules.
-    :param attachment_points: The list of atom index in the core ligand
-      that the r groups should be attached to. If it is empty, connecting points are sought out and matched.
-    """
+    return rlist
 
-    # fixme - special case after changing the API: remove in the future
-    # This is a temporary warning about the change in the interface.
-    # This change is because there are situations where the attachment_points do not need to be passed to the function.
-    if (
-        isinstance(r_groups, list)
-        and len(r_groups) > 0
-        and isinstance(r_groups[0], int)
-    ):
-        print(
-            'Warning: second argument is detected to be an integer. It is now "r_groups" '
-            "whereas attachement_points are provided as the 3rd argument. "
-        )
-        raise Exception(
-            "Please note that after adding the linker to FEgrow (version 1.1), "
-            'the "build_molecules" function interface has changed to'
-            ' "build_molecules(core_ligand, r_groups, attachment_points)". '
-        )
 
-    # ensure template and r_group are lists
-    if not issubclass(templates.__class__, List):
-        templates = [templates]
-    if not issubclass(r_groups.__class__, List):
-        r_groups = [r_groups]
+def rep2D(mol, idx=-1, rdkit_mol=False, **kwargs):
+    numbered = copy.deepcopy(mol)
+    numbered.RemoveAllConformers()
+    if idx:
+        for atom in numbered.GetAtoms():
+            atom.SetAtomMapNum(atom.GetIdx())
+    AllChem.Compute2DCoords(numbered)
 
-    # make a deep copy of r_groups/linkers to ensure we don't modify the library
-    templates = [copy.deepcopy(mol) for mol in templates]
-    r_groups = [copy.deepcopy(mol) for mol in r_groups]
+    if rdkit_mol:
+        return numbered
+    else:
+        return Draw.MolToImage(numbered, **kwargs)
 
-    # get attachment points for each template
-    if not attachment_points:
-        # attempt to generate the attachment points by picking the joining molecule
-        # case: a list of templates previously joined with linkers requires iterating over them
-        attachment_points = [__getAttachmentVector(lig)[0].GetIdx() for lig in templates]
 
-    if not attachment_points:
-        raise Exception("Could not find attachement points. ")
-
-    if len(attachment_points) != len(templates):
-        raise Exception(
-            f"There must be one attachment point for each template. "
-            f"Provided attachement points = {len(attachment_points)} "
-            f"with templates number: {len(templates)}"
-        )
-
-    combined_mols = RList()
-    id_counter = 0
-    for atom_idx, core_ligand in zip(attachment_points, templates):
-        for r_mol in r_groups:
-            core_mol = RMol(copy.deepcopy(core_ligand))
-            merged_mol = merge_R_group(
-                scaffold=core_mol, RGroup=r_mol, replace_index=atom_idx
-            )
-            # assign the identifying index to the molecule
-            merged_mol.id = id_counter
-            combined_mols.append(merged_mol)
-            id_counter += 1
-
-    return combined_mols
+def rep3D(mol):
+    viewer = py3Dmol.view(width=300, height=300, viewergrid=(1, 1))
+    for i in range(mol.GetNumConformers()):
+        mb = Chem.MolToMolBlock(mol, confId=i)
+        viewer.addModel(mb, "mol")
+    viewer.setStyle({"stick": {}})
+    viewer.zoomTo()
+    return viewer

--- a/fegrow/package.py
+++ b/fegrow/package.py
@@ -24,12 +24,12 @@ from .conformers import generate_conformers
 from .toxicity import tox_props
 
 # default options
-pandas.set_option('display.precision', 3)
+pandas.set_option("display.precision", 3)
 
 logger = logging.getLogger(__name__)
 
 
-class RInterface():
+class RInterface:
     """
     This is a shared interface for a molecule and a list of molecules.
 
@@ -227,7 +227,11 @@ class RMol(RInterface, rdkit.Chem.rdchem.Mol):
         return rep2D(self, **kwargs)
 
     def rep3D(
-        self, view=None, prody_protein=None, template=False, confIds: Optional[List[int]] = None
+        self,
+        view=None,
+        prody_protein=None,
+        template=False,
+        confIds: Optional[List[int]] = None,
     ):
         """
         Use py3Dmol to obtain the 3D view of the molecule.
@@ -292,14 +296,18 @@ class RMol(RInterface, rdkit.Chem.rdchem.Mol):
 
         for conf in list(self.GetConformers()):
             # for each atom check how far it is from the protein atoms
-            min_dst = 999_999_999 # arbitrary large distance
+            min_dst = 999_999_999  # arbitrary large distance
             for point in conf.GetPositions():
-                shortest = np.min(np.sqrt(np.sum((point - protein_coords) ** 2, axis=1)))
+                shortest = np.min(
+                    np.sqrt(np.sum((point - protein_coords) ** 2, axis=1))
+                )
                 min_dst = min(min_dst, shortest)
 
             if min_dst < min_dst_allowed:
                 self.RemoveConformer(conf.GetId())
-                logger.debug(f"Clash with the protein. Removing conformer id: {conf.GetId()}")
+                logger.debug(
+                    f"Clash with the protein. Removing conformer id: {conf.GetId()}"
+                )
 
     @staticmethod
     def set_gnina(loc):
@@ -353,7 +361,9 @@ class RMol(RInterface, rdkit.Chem.rdchem.Mol):
         os.chmod(gnina, mode | stat.S_IEXEC)
 
         # check if it works
-        subprocess.run(["./gnina", "--help"], capture_output=True, check=True, cwd=RMol.gnina_dir)
+        subprocess.run(
+            ["./gnina", "--help"], capture_output=True, check=True, cwd=RMol.gnina_dir
+        )
 
     def gnina(self, receptor_file):
         """
@@ -392,7 +402,8 @@ class RMol(RInterface, rdkit.Chem.rdchem.Mol):
                 "False",
             ],
             capture_output=True,
-            check=True)
+            check=True,
+        )
 
         output = process.stdout.decode("utf-8")
         CNNaffinities_str = re.findall(r"CNNaffinity: (-?\d+.\d+)", output)
@@ -429,7 +440,7 @@ class RMol(RInterface, rdkit.Chem.rdchem.Mol):
         file_type = file_name.split(".")[-1]
 
         # SDF has its own multi-frame writer
-        if file_type.lower() == 'sdf':
+        if file_type.lower() == "sdf":
             with Chem.SDWriter(file_name) as SD:
                 for conformer in self.GetConformers():
                     SD.write(self, confId=conformer.GetId())
@@ -609,7 +620,7 @@ class RGroupGrid(mols2grid.MolGrid):
         builtin_rgroups = Path(__file__).parent / "data" / "rgroups" / "library.sdf"
         for rgroup in Chem.SDMolSupplier(str(builtin_rgroups), removeHs=False):
             molecules.append(rgroup)
-            names.append(rgroup.GetProp('SMILES'))
+            names.append(rgroup.GetProp("SMILES"))
 
             # highlight the attachment atom
             for atom in rgroup.GetAtoms():
@@ -620,6 +631,7 @@ class RGroupGrid(mols2grid.MolGrid):
 
     def _ipython_display_(self):
         from IPython.display import display_html
+
         subset = ["img", "Name", "mols2grid-id"]
         display_html(self.display(subset=subset, substruct_highlight=True))
 
@@ -659,17 +671,18 @@ class RLinkerGrid(mols2grid.MolGrid):
         linkers = []
         for mol in Chem.SDMolSupplier(str(builtin_rlinkers), removeHs=False):
             # use easier searchable SMILES, e.g. [*:1] was replaced with R1
-            display_name = mol.GetProp('display_smiles')
+            display_name = mol.GetProp("display_smiles")
 
             # extract the index property from the original publication
             smile_index = mol.GetIntProp("SmileIndex")
 
             linkers.append([mol, display_name, smile_index])
 
-        return pandas.DataFrame(linkers, columns=['Mol', 'Name', 'Common'])
+        return pandas.DataFrame(linkers, columns=["Mol", "Name", "Common"])
 
     def _ipython_display_(self):
         from IPython.display import display
+
         subset = ["img", "Name", "mols2grid-id"]
         return display(self.display(subset=subset, substruct_highlight=True))
 
@@ -679,10 +692,10 @@ class RLinkerGrid(mols2grid.MolGrid):
 
 
 def build_molecules(
-        templates: Union[Chem.Mol, List[Chem.Mol]],
-        r_groups: Union[Chem.Mol, List[Chem.Mol], int],
-        attachment_points: Optional[List[int]] = None,
-        keep_components: Optional[List[int]] = None,
+    templates: Union[Chem.Mol, List[Chem.Mol]],
+    r_groups: Union[Chem.Mol, List[Chem.Mol], int],
+    attachment_points: Optional[List[int]] = None,
+    keep_components: Optional[List[int]] = None,
 ):
     """
 
@@ -693,7 +706,9 @@ def build_molecules(
         submolecules, keep the submolecule with this atom index.
     :return:
     """
-    built_mols = build_molecules_with_rdkit(templates, r_groups, attachment_points, keep_components)
+    built_mols = build_molecules_with_rdkit(
+        templates, r_groups, attachment_points, keep_components
+    )
     rlist = RList()
     for mol, scaffold_no_attachement in built_mols:
         rmol = RMol(mol)

--- a/fegrow/package.py
+++ b/fegrow/package.py
@@ -682,8 +682,18 @@ def build_molecules(
         templates: Union[Chem.Mol, List[Chem.Mol]],
         r_groups: Union[Chem.Mol, List[Chem.Mol], int],
         attachment_points: Optional[List[int]] = None,
+        keep_components: Optional[List[int]] = None,
 ):
-    built_mols = build_molecules_with_rdkit(templates, r_groups, attachment_points)
+    """
+
+    :param templates:
+    :param r_groups:
+    :param attachment_points:
+    :param keep_components: When the scaffold is grown from an internal atom that divides the molecules into separate
+        submolecules, keep the submolecule with this atom index.
+    :return:
+    """
+    built_mols = build_molecules_with_rdkit(templates, r_groups, attachment_points, keep_components)
     rlist = RList()
     for mol, scaffold_no_attachement in built_mols:
         rmol = RMol(mol)

--- a/fegrow/package.py
+++ b/fegrow/package.py
@@ -17,7 +17,7 @@ import prody
 import py3Dmol
 import rdkit
 from rdkit import Chem
-from rdkit.Chem import AllChem, Draw, PandasTools
+from rdkit.Chem import Draw, PandasTools
 
 from .builder import build_molecules_with_rdkit
 from .conformers import generate_conformers
@@ -699,7 +699,7 @@ def rep2D(mol, idx=-1, rdkit_mol=False, **kwargs):
     if idx:
         for atom in numbered.GetAtoms():
             atom.SetAtomMapNum(atom.GetIdx())
-    AllChem.Compute2DCoords(numbered)
+    Chem.AllChem.Compute2DCoords(numbered)
 
     if rdkit_mol:
         return numbered

--- a/fegrow/receptor.py
+++ b/fegrow/receptor.py
@@ -190,7 +190,9 @@ def optimise_in_receptor(
     )
 
     # save the receptor coords as they should be consistent
-    receptor_coords = unit.Quantity(parmed_receptor.coordinates.tolist(), unit=unit.angstrom)
+    receptor_coords = unit.Quantity(
+        parmed_receptor.coordinates.tolist(), unit=unit.angstrom
+    )
 
     # loop over the conformers and energy minimise and store the final positions
     final_mol = RMol(deepcopy(ligand))

--- a/fegrow/testing/asapsmiles/asapsmiles.py
+++ b/fegrow/testing/asapsmiles/asapsmiles.py
@@ -4,13 +4,13 @@ import prody
 
 
 # load the common core
-core = Chem.SDMolSupplier('core.sdf')[0]
+core = Chem.SDMolSupplier("core.sdf")[0]
 
 # create RList of molecules from smiles
 rlist = RList()
 params = Chem.SmilesParserParams()
-params.removeHs = False # keep the hydrogens
-for smiles in open('sars_generated_smiles.txt').readlines():
+params.removeHs = False  # keep the hydrogens
+for smiles in open("sars_generated_smiles.txt").readlines():
     mol = Chem.MolFromSmiles(smiles.strip(), params=params)
     rlist.append(RMol(mol))
 
@@ -18,12 +18,14 @@ for smiles in open('sars_generated_smiles.txt').readlines():
 for rmol in rlist:
     # check if the core_mol is a substructure
     if not rmol.HasSubstructMatch(core):
-        raise Exception('The core molecule is not a substructure of one of the RMols in the RList, '
-                        'according to Mol.HasSubstructMatch')
+        raise Exception(
+            "The core molecule is not a substructure of one of the RMols in the RList, "
+            "according to Mol.HasSubstructMatch"
+        )
     rmol._save_template(core)
 
 # conformers and energies, example for one molecule
-mol_id = 1 # 5 broken, wrong number of atoms
+mol_id = 1  # 5 broken, wrong number of atoms
 rlist[mol_id].generate_conformers(num_conf=100, minimum_conf_rms=0.5)
 protein_filename = "rec_final.pdb"
 rec_final = prody.parsePDB(protein_filename)
@@ -38,12 +40,12 @@ if rlist[mol_id].GetNumConformers() > 0:
         sigma_scale_factor=0.8,
         relative_permittivity=4,
         water_model=None,
-        platform_name='CPU',
+        platform_name="CPU",
     )
     rlist[mol_id].sort_conformers(energy_range=5)
 
     affinities = rlist[mol_id].gnina(receptor_file=protein_filename)
 
-    with Chem.SDWriter(f'Rmol{mol_id}_best_conformers.sdf') as SDW:
+    with Chem.SDWriter(f"Rmol{mol_id}_best_conformers.sdf") as SDW:
         for conformer in rlist[mol_id].GetConformers():
             SDW.write(rlist[mol_id], confId=conformer.GetId())

--- a/fegrow/testing/test_general.py
+++ b/fegrow/testing/test_general.py
@@ -17,7 +17,7 @@ root = pathlib.Path(__file__).parent
 def sars_core_scaffold():
     params = Chem.SmilesParserParams()
     params.removeHs = False  # keep the hydrogens
-    scaffold = Chem.MolFromSmiles('[H]c1c([H])c([H])n([H])c(=O)c1[H]', params=params)
+    scaffold = Chem.MolFromSmiles("[H]c1c([H])c([H])n([H])c(=O)c1[H]", params=params)
     Chem.AllChem.Compute2DCoords(scaffold)
     return scaffold
 
@@ -26,17 +26,19 @@ def test_adding_ethanol_1mol(sars_core_scaffold):
     # use a hydrogen bond N-H
     attachment_index = [7]
     ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
-    rmols = fegrow.build_molecules(sars_core_scaffold, [ethanol_rgroup], attachment_index)
+    rmols = fegrow.build_molecules(
+        sars_core_scaffold, [ethanol_rgroup], attachment_index
+    )
 
     assert len(rmols) == 1, "Did not generate 1 molecule"
 
 
 def test_growing_keep_larger_component(sars_core_scaffold):
     """
-     When a growing vector is an internal atom that divides the molecule,
-     the largest component becomes the scaffold.
+    When a growing vector is an internal atom that divides the molecule,
+    the largest component becomes the scaffold.
     """
-    scaffold = Chem.MolFromSmiles('O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1')
+    scaffold = Chem.MolFromSmiles("O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1")
     Chem.AddHs(scaffold)
     Chem.AllChem.Compute2DCoords(scaffold)
 
@@ -45,17 +47,17 @@ def test_growing_keep_larger_component(sars_core_scaffold):
     ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
     rmol = fegrow.build_molecules(scaffold, [ethanol_rgroup], attachment_index).pop()
 
-    assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == 'O=c1c(CCO)cccn1-c1cccnc1'
+    assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == "O=c1c(CCO)cccn1-c1cccnc1"
 
 
 def test_growing_keep_cue_component(sars_core_scaffold):
     """
-     When a growing vector is an atom that divides the molecule,
-     the user can specify which side to keep.
+    When a growing vector is an atom that divides the molecule,
+    the user can specify which side to keep.
 
-     Keep the smaller chlorinated benzene ring for growing ethanol
+    Keep the smaller chlorinated benzene ring for growing ethanol
     """
-    scaffold = Chem.MolFromSmiles('O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1')
+    scaffold = Chem.MolFromSmiles("O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1")
     Chem.AddHs(scaffold)
     Chem.AllChem.Compute2DCoords(scaffold)
 
@@ -63,9 +65,11 @@ def test_growing_keep_cue_component(sars_core_scaffold):
     attachment_index = [2]
     keep_smaller_ring = [3]
     ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
-    rmol = fegrow.build_molecules(scaffold, [ethanol_rgroup], attachment_index, keep_smaller_ring).pop()
+    rmol = fegrow.build_molecules(
+        scaffold, [ethanol_rgroup], attachment_index, keep_smaller_ring
+    ).pop()
 
-    assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == 'OCCc1cccc(Cl)c1'
+    assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == "OCCc1cccc(Cl)c1"
 
 
 def test_adding_ethanol_number_of_atoms():
@@ -137,7 +141,7 @@ def test_add_a_linker_check_star():
     )[0]
     attachment_index = [40]
     # Select a linker
-    linker = RLinkers[RLinkers.Name == 'R1NC(R2)=O'].Mol.values[0]
+    linker = RLinkers[RLinkers.Name == "R1NC(R2)=O"].Mol.values[0]
     template_with_linker = fegrow.build_molecules(
         template_mol, [linker], attachment_index
     )[0]
@@ -150,13 +154,15 @@ def test_two_linkers_two_rgroups():
     # Check combinatorial: ie 2 rgroups and 2 linkers create 4 molecles that contain both
 
     # get two R-groups
-    R_group_ethanol = RGroups[RGroups.Name == '*CCO'].Mol.values[0]
-    R_group_cyclopropane = RGroups[RGroups.Name == '*C1CC1'].Mol.values[0]
+    R_group_ethanol = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
+    R_group_cyclopropane = RGroups[RGroups.Name == "*C1CC1"].Mol.values[0]
 
     # get two linkers
-    linker1 = RLinkers[RLinkers.Name == 'R1CR2'].Mol.values[0]
-    linker2 = RLinkers[RLinkers.Name == 'R1OR2'].Mol.values[0]
+    linker1 = RLinkers[RLinkers.Name == "R1CR2"].Mol.values[0]
+    linker2 = RLinkers[RLinkers.Name == "R1OR2"].Mol.values[0]
 
-    built_molecules = fegrow.build_molecules([linker1, linker2], [R_group_ethanol, R_group_cyclopropane])
+    built_molecules = fegrow.build_molecules(
+        [linker1, linker2], [R_group_ethanol, R_group_cyclopropane]
+    )
 
     assert len(built_molecules) == 4

--- a/fegrow/testing/test_general.py
+++ b/fegrow/testing/test_general.py
@@ -25,7 +25,7 @@ def sars_core_scaffold():
 def test_adding_ethanol_1mol(sars_core_scaffold):
     # use a hydrogen bond N-H
     attachment_index = [7]
-    ethanol_rgroup = RGroups.loc[RGroups["Name"] == "*CCO"].Mol.values[0]
+    ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
     rmols = fegrow.build_molecules(sars_core_scaffold, [ethanol_rgroup], attachment_index)
 
     assert len(rmols) == 1, "Did not generate 1 molecule"
@@ -38,7 +38,7 @@ def test_growing_bond_oxygen(sars_core_scaffold):
     sars_core_scaffold_no_nh = emol.GetMol()
 
     attachment_index = [8]  # C-O
-    ethanol_rgroup = RGroups.loc[RGroups["Name"] == "*CCO"].Mol.values[0]
+    ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
 
     rmols = fegrow.build_molecules(sars_core_scaffold_no_nh, [ethanol_rgroup], attachment_index)
 
@@ -54,8 +54,7 @@ def test_adding_ethanol_number_of_atoms():
     attachment_index = [40]
 
     # get a group
-    groups = RGroups.dataframe
-    ethanol = groups.loc[groups["Name"] == "*CCO"]["Mol"].values[0]
+    ethanol = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
     ethanol_atoms_num = ethanol.GetNumAtoms()
 
     # merge
@@ -72,9 +71,8 @@ def test_growing_plural_groups():
     attachment_index = [40]
 
     # get r-group
-    groups = RGroups.dataframe
-    ethanol = groups.loc[groups["Name"] == "*CCO"]["Mol"].values[0]
-    cyclopropane = groups.loc[groups["Name"] == "*C1CC1"]["Mol"].values[0]
+    ethanol = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
+    cyclopropane = RGroups[RGroups.Name == "*C1CC1"].Mol.values[0]
 
     rmols = fegrow.build_molecules(
         template_mol, [ethanol, cyclopropane], attachment_index
@@ -91,8 +89,7 @@ def test_added_ethanol_conformer_generation():
     attachment_index = [40]
 
     # get r-group
-    groups = RGroups.dataframe
-    ethanol = groups.loc[groups["Name"] == "*CCO"]["Mol"].values[0]
+    ethanol = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
 
     rmols = fegrow.build_molecules(template_mol, [ethanol], attachment_index)
 
@@ -116,9 +113,8 @@ def test_add_a_linker_check_star():
         str(root / "data" / "sarscov2_coreh.sdf"), removeHs=False
     )[0]
     attachment_index = [40]
-    df = RLinkers.dataframe
     # Select a linker
-    linker = df.loc[df["mols2grid-id"] == 842]["Mol"].values[0]
+    linker = RLinkers[RLinkers.Name == 'R1NC(R2)=O'].Mol.values[0]
     template_with_linker = fegrow.build_molecules(
         template_mol, [linker], attachment_index
     )[0]
@@ -131,14 +127,12 @@ def test_two_linkers_two_rgroups():
     # Check combinatorial: ie 2 rgroups and 2 linkers create 4 molecles that contain both
 
     # get two R-groups
-    groups = RGroups.dataframe
-    R_group_ethanol = groups.loc[groups['Name'] == '*CCO']['Mol'].values[0]
-    R_group_cyclopropane = groups.loc[groups['Name'] == '*C1CC1']['Mol'].values[0]
+    R_group_ethanol = RGroups[RGroups.Name == '*CCO'].Mol.values[0]
+    R_group_cyclopropane = RGroups[RGroups.Name == '*C1CC1'].Mol.values[0]
 
     # get two linkers
-    df = RLinkers.dataframe
-    linker1 = df.loc[df['Name'] == 'R1CR2']['Mol'].values[0]
-    linker2 = df.loc[df['Name'] == 'R1CR2']['Mol'].values[0]
+    linker1 = RLinkers[RLinkers.Name == 'R1CR2'].Mol.values[0]
+    linker2 = RLinkers[RLinkers.Name == 'R1OR2'].Mol.values[0]
 
     built_molecules = fegrow.build_molecules([linker1, linker2], [R_group_ethanol, R_group_cyclopropane])
 

--- a/fegrow/testing/test_general.py
+++ b/fegrow/testing/test_general.py
@@ -31,18 +31,21 @@ def test_adding_ethanol_1mol(sars_core_scaffold):
     assert len(rmols) == 1, "Did not generate 1 molecule"
 
 
-def test_growing_bond_oxygen(sars_core_scaffold):
-    # deprotonate N to enable kekulization of the molecule
-    emol = Chem.EditableMol(sars_core_scaffold)
-    emol.RemoveAtom(7)
-    sars_core_scaffold_no_nh = emol.GetMol()
+def test_growing_keep_larger_component(sars_core_scaffold):
+    """
+     When a growing vector is a random internal atom, the molecule is divided using that atom,
+     and the largest component becomes the scaffold.
+    """
+    scaffold = Chem.MolFromSmiles('O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1')
+    Chem.AddHs(scaffold)
+    Chem.AllChem.Compute2DCoords(scaffold)
 
-    attachment_index = [8]  # C-O
+    # use C on the chlorinated benzene
+    attachment_index = [3]
     ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
+    rmol = fegrow.build_molecules(scaffold, [ethanol_rgroup], attachment_index).pop()
 
-    rmols = fegrow.build_molecules(sars_core_scaffold_no_nh, [ethanol_rgroup], attachment_index)
-
-    assert len(rmols) == 1, "Did not generate 1 molecule"
+    assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == 'O=c1c(CCO)cccn1-c1cccnc1'
 
 
 def test_adding_ethanol_number_of_atoms():

--- a/fegrow/testing/test_general.py
+++ b/fegrow/testing/test_general.py
@@ -33,8 +33,8 @@ def test_adding_ethanol_1mol(sars_core_scaffold):
 
 def test_growing_keep_larger_component(sars_core_scaffold):
     """
-     When a growing vector is a random internal atom, the molecule is divided using that atom,
-     and the largest component becomes the scaffold.
+     When a growing vector is an internal atom that divides the molecule,
+     the largest component becomes the scaffold.
     """
     scaffold = Chem.MolFromSmiles('O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1')
     Chem.AddHs(scaffold)
@@ -46,6 +46,26 @@ def test_growing_keep_larger_component(sars_core_scaffold):
     rmol = fegrow.build_molecules(scaffold, [ethanol_rgroup], attachment_index).pop()
 
     assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == 'O=c1c(CCO)cccn1-c1cccnc1'
+
+
+def test_growing_keep_cue_component(sars_core_scaffold):
+    """
+     When a growing vector is an atom that divides the molecule,
+     the user can specify which side to keep.
+
+     Keep the smaller chlorinated benzene ring for growing ethanol
+    """
+    scaffold = Chem.MolFromSmiles('O=c1c(-c2cccc(Cl)c2)cccn1-c1cccnc1')
+    Chem.AddHs(scaffold)
+    Chem.AllChem.Compute2DCoords(scaffold)
+
+    # use C on the chlorinated benzene
+    attachment_index = [2]
+    keep_smaller_ring = [3]
+    ethanol_rgroup = RGroups[RGroups.Name == "*CCO"].Mol.values[0]
+    rmol = fegrow.build_molecules(scaffold, [ethanol_rgroup], attachment_index, keep_smaller_ring).pop()
+
+    assert Chem.MolToSmiles(Chem.RemoveHs(rmol)) == 'OCCc1cccc(Cl)c1'
 
 
 def test_adding_ethanol_number_of_atoms():

--- a/notebooks/.tutorial.py
+++ b/notebooks/.tutorial.py
@@ -230,7 +230,7 @@ rec_final = prody.parsePDB("rec_final.pdb")
 # In[ ]:
 
 
-rmols[0].rep3D(prody=rec_final)
+rmols[0].rep3D(prody_protein=rec_final)
 
 
 # Any conformers that clash with the protein (any atom-atom distance less than 1 Angstrom), are removed.
@@ -244,7 +244,7 @@ rmols.remove_clashing_confs(rec_final)
 # In[ ]:
 
 
-rmols[0].rep3D(prody=rec_final)
+rmols[0].rep3D(prody_protein=rec_final)
 
 
 # ### Optimise conformers in context of protein


### PR DESCRIPTION
 - added a test case with `-O` which requires deprotonating the neighbouring N first
 - refactoring, builder is not in its own file

To do:

- [x]  Pick a smaller disconnected component if someone select a random atom

Questions:
- [ ] Should we offer automatic protonation using openbabel API if it's not a hydrogen?  