### PR TITLE
Keeping original scaffold

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,8 @@ Authors: Mateusz K. Bieniek, Ben Cree, Rachael Pirie, Joshua T. Horton, Natalie 
  - The user now has to import the libraries (RGroupGrid) and instantiate first.
  - Libraries (linkers, rgroups) are now single .sdf files to avoid problems on clusters with many small files
  - A growing vector can now be any molecule-separating atom in the molecule.
+ - When growing a molecule C multiple time in the same session (e.g. +linker +R), the .template attribute will
+    always be the original C
 
 **version 1.3.0**
 

--- a/fegrow/builder.py
+++ b/fegrow/builder.py
@@ -93,7 +93,7 @@ def build_molecules_with_rdkit(
             )
             # assign the identifying index to the molecule
             merged_mol.id = id_counter
-            combined_mols.append((merged_mol, scaffold_no_attachement))
+            combined_mols.append((merged_mol, scaffold_ligand, scaffold_no_attachement))
             id_counter += 1
 
     return combined_mols

--- a/fegrow/conformers.py
+++ b/fegrow/conformers.py
@@ -32,6 +32,7 @@ def generate_conformers(
     num_conf: int,
     minimum_conf_rms: Optional[float] = None,
     flexible: Optional[List[int]] = [],
+    use_ties_mcs: bool = False,
 ) -> List[Chem.rdchem.Mol]:
     """
     flexible:
@@ -45,7 +46,7 @@ def generate_conformers(
 
     # map scaffold atoms to the new molecules
     match = rmol.GetSubstructMatch(scaffold_mol)
-    if match:
+    if match and not use_ties_mcs:
         # remember the scaffold coordinates
         coordMap = {}
         manmap = []

--- a/fegrow/conformers.py
+++ b/fegrow/conformers.py
@@ -28,7 +28,7 @@ def duplicate_conformers(
 
 
 def generate_conformers(
-    RMol: Chem.rdchem.Mol,
+    rmol: Chem.rdchem.Mol,
     num_conf: int,
     minimum_conf_rms: Optional[float] = None,
     flexible: Optional[List[int]] = [],
@@ -37,27 +37,59 @@ def generate_conformers(
     flexible:
             The list of atomic indices on the @core_ligand that should not be constrained during the conformer generation
     """
-    scaffold_mol = deepcopy(RMol.template)
+    scaffold_mol = deepcopy(rmol.template)
     coreConf = scaffold_mol.GetConformer(0)
 
     # fixme - check if the conformer has H, it helps with conformer generation
-    rmol = deepcopy(RMol)
+    rmol = deepcopy(rmol)
 
     # map scaffold atoms to the new molecules
     match = rmol.GetSubstructMatch(scaffold_mol)
-    if not match:
-        raise WrongCoreForMolecule("molecule doesn't match the core", match)
+    if match:
+        # remember the scaffold coordinates
+        coordMap = {}
+        manmap = []
+        for coreI, matchedMolI in enumerate(match):
+            if matchedMolI in flexible:
+                continue
 
-    # remember the scaffold coordinates
-    coordMap = {}
-    manmap = []
-    for coreI, matchedMolI in enumerate(match):
-        if matchedMolI in flexible:
-            continue
+            corePtI = coreConf.GetAtomPosition(coreI)
+            coordMap[matchedMolI] = corePtI
+            manmap.append((matchedMolI, coreI))
+    else:
+        try:
+            from ties.topology_superimposer import superimpose_topologies, Atom, get_starting_configurations
+        except ModuleNotFoundError as NoTies:
+            raise WrongCoreForMolecule("Molecule doesn't match the core. "
+                                       "This can be caused by the order of SMILES, for example. "
+                                       "You can install the python package 'ties' to use MCS instead. ", match) from NoTies
 
-        corePtI = coreConf.GetAtomPosition(coreI)
-        coordMap[matchedMolI] = corePtI
-        manmap.append((matchedMolI, coreI))
+        def to_ties_atoms(rdkit_mol):
+            ties_atoms = {}
+            for rdkit_atom in rdkit_mol.GetAtoms():
+                ties_atom = Atom(name=rdkit_atom.GetSymbol() + str(rdkit_atom.GetIdx()), atom_type=rdkit_atom.GetSymbol())
+                ties_atom.id = rdkit_atom.GetIdx()
+                ties_atoms[rdkit_atom.GetIdx()] = ties_atom
+
+            for bond in rdkit_mol.GetBonds():
+                ties_atoms[bond.GetBeginAtomIdx()].bind_to(ties_atoms[bond.GetEndAtomIdx()], str(bond.GetBondType()))
+            return list(ties_atoms.values())
+
+        rmol_ties = to_ties_atoms(rmol)
+        scaffold_ties = to_ties_atoms(scaffold_mol)
+        mapping = superimpose_topologies(scaffold_ties, rmol_ties, ignore_coords=True, ignore_charges_completely=True)
+
+        coordMap = {}
+        manmap = []
+        for coreI, matchedMolI in sorted(mapping.matched_pairs, key = lambda p: p[0].id):
+            if matchedMolI.id in flexible:
+                continue
+
+            corePtI = coreConf.GetAtomPosition(coreI.id)
+            coordMap[matchedMolI.id] = corePtI
+            manmap.append((matchedMolI.id, coreI.id))
+        #
+        print("Used the TIES (Bieniek et al) package to get the mapping")
 
     # use a reproducible random seed
     randomseed = 194715
@@ -139,7 +171,7 @@ def ConstrainedEmbedR2(
         useSmallRingTorsions=True,
     )
     if ci < 0:
-        raise ValueError("Could not embed molecule.")
+        raise ValueError("Could not embed molecule.", mol, coordMap)
 
     # rms = AlignMol(mol, core, atomMap=manmap)
     # mol.SetProp('EmbedRMS', str(rms))

--- a/fegrow/package.py
+++ b/fegrow/package.py
@@ -725,7 +725,7 @@ def build_molecules(
     for mol, scaffold, scaffold_no_attachement in built_mols:
         rmol = RMol(mol)
 
-        if isinstance(scaffold.template, rdkit.Chem.Mol):
+        if hasattr(scaffold, 'template') and isinstance(scaffold.template, rdkit.Chem.Mol):
             # save the original scaffold (e.g. before the linker was added)
             # this means that conformer generation will always have to regenerate the previously added R-groups/linkers
             rmol._save_template(scaffold.template)

--- a/fegrow/package.py
+++ b/fegrow/package.py
@@ -722,9 +722,15 @@ def build_molecules(
         templates, r_groups, attachment_points, keep_components
     )
     rlist = RList()
-    for mol, scaffold_no_attachement in built_mols:
+    for mol, scaffold, scaffold_no_attachement in built_mols:
         rmol = RMol(mol)
-        rmol._save_template(scaffold_no_attachement)
+
+        if isinstance(scaffold.template, rdkit.Chem.Mol):
+            # save the original scaffold (e.g. before the linker was added)
+            # this means that conformer generation will always have to regenerate the previously added R-groups/linkers
+            rmol._save_template(scaffold.template)
+        else:
+            rmol._save_template(scaffold_no_attachement)
         rlist.append(rmol)
 
     return rlist


### PR DESCRIPTION
Extending the molecule M multiple times was changing the scaffold, e.g. +linker and then +R was updating the scaffold to be m.linker instead of the original M. 

We also have here an alternative that uses TIES, if it's available, to generate the superimposition for the conformer generation. This is not switched on by default for now. 