### PR TITLE
No Hs in RMS to avoid the wrong hydrogens being compared

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -5,6 +5,7 @@ channels:
 
 dependencies:
   - conda-forge::python>=3.8
+  - conda-forge::notebook<7.0.0
   - conda-forge::pip
   - conda-forge::rdkit
   - conda-forge::prody

--- a/fegrow/conformers.py
+++ b/fegrow/conformers.py
@@ -4,7 +4,9 @@ from typing import List, Optional
 
 from rdkit import Chem
 from rdkit.Chem import AllChem
-
+from rdkit.Chem.rdDistGeom import EmbedMolecule
+from rdkit.Chem.rdForceFieldHelpers import UFFGetMoleculeForceField
+from rdkit.Chem.rdMolAlign import AlignMol
 
 logger = logging.getLogger(__name__)
 
@@ -104,9 +106,7 @@ def generate_conformers(
             deepcopy(rmol),
             scaffold_mol,
             coordMap,
-            match,
             manmap,
-            flexible,
             randomseed=randomseed + coreI,
         )
 
@@ -124,197 +124,44 @@ def generate_conformers(
     return rmol
 
 
-from rdkit import DataStructs
-from rdkit import ForceField
-from rdkit import RDConfig
-from rdkit import rdBase
-from rdkit.Chem import *
-from rdkit.Chem.ChemicalFeatures import *
-from rdkit.Chem.rdChemReactions import *
-from rdkit.Chem.rdDepictor import *
-from rdkit.Chem.rdDistGeom import *
-from rdkit.Chem.rdForceFieldHelpers import *
-from rdkit.Chem.rdMolAlign import *
-from rdkit.Chem.rdMolDescriptors import *
-from rdkit.Chem.rdMolTransforms import *
-from rdkit.Chem.rdPartialCharges import *
-from rdkit.Chem.rdReducedGraphs import *
-from rdkit.Chem.rdShapeHelpers import *
-from rdkit.Chem.rdqueries import *
-from rdkit.Chem.rdMolEnumerator import *
-from rdkit.Geometry import rdGeometry
-from rdkit.Chem.EnumerateStereoisomers import (
-    StereoEnumerationOptions,
-    EnumerateStereoisomers,
-)
-
-
 def ConstrainedEmbedR2(
     mol,
     core,
-    coordMap,
-    match,
-    manmap,
-    flexible,
-    useTethers=True,
-    coreConfId=-1,
-    randomseed=2342,
+    coordinates_map,
+    indices_map,
+    randomseed=0,
     getForceField=UFFGetMoleculeForceField,
-    **kwargs,
 ):
     ci = EmbedMolecule(
         mol,
-        coordMap=coordMap,
+        coordMap=coordinates_map,
         randomSeed=randomseed,
-        **kwargs,
         useExpTorsionAnglePrefs=True,
         useBasicKnowledge=True,
         enforceChirality=True,
         useSmallRingTorsions=True,
     )
     if ci < 0:
-        raise ValueError("Could not embed molecule.", mol, coordMap)
+        raise ValueError("Could not embed molecule.", mol, coordinates_map)
 
-    # rms = AlignMol(mol, core, atomMap=manmap)
-    # mol.SetProp('EmbedRMS', str(rms))
-    # return mol
+    # rotate the embedded conformation onto the core:
+    rms = AlignMol(mol, core, atomMap=indices_map)
 
-    if not useTethers:
-        print("not using tethers")
-        # clean up the conformation
-        ff = getForceField(mol, confId=0)
-        for i, idxI in enumerate(match):
-            if i in flexible:
-                continue
+    ff = getForceField(mol, confId=0)
+    conf = core.GetConformer()
+    for matched_index, core_index in indices_map:
+        coord = conf.GetAtomPosition(core_index)
+        coord_index = ff.AddExtraPoint(coord.x, coord.y, coord.z, fixed=True) - 1
+        ff.AddDistanceConstraint(coord_index, matched_index, 0, 0, 100.0 * 100)
 
-            for j in range(i + 1, len(match)):
-                if j in flexible:
-                    continue
-
-                idxJ = match[j]
-                d = coordMap[idxI].Distance(coordMap[idxJ])
-                ff.AddDistanceConstraint(idxI, idxJ, d, d, 100.0 * 999999)
-        ff.Initialize()
-        n = 4
-        more = ff.Minimize()
-        while more and n:
-            more = ff.Minimize()
-            n -= 1
-        # rotate the embedded conformation onto the core:
-        rms = AlignMol(mol, core, atomMap=manmap)
-    else:
-        # rotate the embedded conformation onto the core:
-        rms = AlignMol(mol, core, atomMap=manmap)
-        ff = getForceField(mol, confId=0)
-        conf = core.GetConformer()
-        for matchedMolI, coreI in manmap:
-            # for i in range(core.GetNumAtoms()):
-            p = conf.GetAtomPosition(coreI)
-            pIdx = ff.AddExtraPoint(p.x, p.y, p.z, fixed=True) - 1
-            ff.AddDistanceConstraint(pIdx, matchedMolI, 0, 0, 100.0 * 100)
-        ff.Initialize()
-        n = 4
+    ff.Initialize()
+    n = 4
+    more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
+    while more and n:
         more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
-        while more and n:
-            more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
-            n -= 1
-        # realign
-        rms = AlignMol(mol, core, atomMap=manmap)
-    mol.SetProp("EmbedRMS", str(rms))
-    return mol
+        n -= 1
 
-
-def ConstrainedEmbedR(
-    mol,
-    core,
-    useTethers=True,
-    coreConfId=-1,
-    randomseed=2342,
-    getForceField=UFFGetMoleculeForceField,
-    **kwargs,
-):
-    """generates an embedding of a molecule where part of the molecule
-    is constrained to have particular coordinates
-
-    Arguments
-      - mol: the molecule to embed
-      - core: the molecule to use as a source of constraints
-      - useTethers: (optional) if True, the final conformation will be
-          optimized subject to a series of extra forces that pull the
-          matching atoms to the positions of the core atoms. Otherwise
-          simple distance constraints based on the core atoms will be
-          used in the optimization.
-      - coreConfId: (optional) id of the core conformation to use
-      - randomSeed: (optional) seed for the random number generator
-
-
-    An example, start by generating a template with a 3D structure:
-
-    >>> from rdkit.Chem import AllChem
-    >>> template = AllChem.MolFromSmiles("c1nn(Cc2ccccc2)cc1")
-    >>> AllChem.EmbedMolecule(template)
-    0
-    >>> AllChem.UFFOptimizeMolecule(template)
-    0
-
-    Here's a molecule:
-
-    >>> mol = AllChem.MolFromSmiles("c1nn(Cc2ccccc2)cc1-c3ccccc3")
-
-    Now do the constrained embedding
-    >>> newmol=AllChem.ConstrainedEmbed(mol, template)
-
-    Demonstrate that the positions are the same:
-
-    >>> newp=newmol.GetConformer().GetAtomPosition(0)
-    >>> molp=mol.GetConformer().GetAtomPosition(0)
-    >>> list(newp-molp)==[0.0,0.0,0.0]
-    True
-    >>> newp=newmol.GetConformer().GetAtomPosition(1)
-    >>> molp=mol.GetConformer().GetAtomPosition(1)
-    >>> list(newp-molp)==[0.0,0.0,0.0]
-    True
-
-    """
-
-    ci = EmbedMolecule(mol, coordMap=coordMap, randomSeed=randomseed, **kwargs)
-    if ci < 0:
-        raise ValueError("Could not embed molecule.")
-
-    algMap = [(j, i) for i, j in enumerate(match)]
-
-    if not useTethers:
-        # clean up the conformation
-        ff = getForceField(mol, confId=0)
-        for i, idxI in enumerate(match):
-            for j in range(i + 1, len(match)):
-                idxJ = match[j]
-                d = coordMap[idxI].Distance(coordMap[idxJ])
-                ff.AddDistanceConstraint(idxI, idxJ, d, d, 100.0 * 999999)
-        ff.Initialize()
-        n = 4
-        more = ff.Minimize()
-        while more and n:
-            more = ff.Minimize()
-            n -= 1
-        # rotate the embedded conformation onto the core:
-        rms = AlignMol(mol, core, atomMap=algMap)
-    else:
-        # rotate the embedded conformation onto the core:
-        rms = AlignMol(mol, core, atomMap=algMap)
-        ff = getForceField(mol, confId=0)
-        conf = core.GetConformer()
-        for i in range(core.GetNumAtoms()):
-            p = conf.GetAtomPosition(i)
-            pIdx = ff.AddExtraPoint(p.x, p.y, p.z, fixed=True) - 1
-            ff.AddDistanceConstraint(pIdx, match[i], 0, 0, 100.0)
-        ff.Initialize()
-        n = 4
-        more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
-        while more and n:
-            more = ff.Minimize(energyTol=1e-4, forceTol=1e-3)
-            n -= 1
-        # realign
-        rms = AlignMol(mol, core, atomMap=algMap)
+    # realign
+    rms = AlignMol(mol, core, atomMap=indices_map)
     mol.SetProp("EmbedRMS", str(rms))
     return mol

--- a/fegrow/receptor.py
+++ b/fegrow/receptor.py
@@ -144,7 +144,7 @@ def optimise_in_receptor(
     system_generator = SystemGenerator(
         forcefields=forcefields,
         small_molecule_forcefield=ligand_force_fields[ligand_force_field],
-        cache="db.json",
+        cache=None,
         molecules=openff_mol,
     )
     # now make a combined receptor and ligand topology


### PR DESCRIPTION
The RMS was taking into account the hydrogens before. However, generating new conformers often left the hydrogens mismatched to other in the grown region. For example, in the case of methyl, the mapping of the hydrogens could be wrong. This was translating to a lot of conformers surviving even though they had in fact RMS = 0 of the heavy atoms. 

+ clean up 