### PR TITLE
The latest pytorch has a build version on conda-forge rather than the…

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -19,7 +19,7 @@ dependencies:
   - conda-forge::tqdm
   - conda-forge::openbabel
   - conda-forge::torchani>2.2.0
-  - conda-forge::pytorch-gpu>=1.10.0
+  - conda-forge::pytorch>=1.10.0
   - conda-forge::openmm-torch>=0.8
   - conda-forge::pint<0.20.0
   - conda-forge::py3dmol>=1.8.0


### PR DESCRIPTION
… name. They either have a cpu build or a gpu one.