### PR TITLE
CLI high throughput scoring 

### DIFF
--- a/fegrow/cli/cli.py
+++ b/fegrow/cli/cli.py
@@ -1,0 +1,30 @@
+import pathlib
+
+import click
+from fegrow.cli.scoring import score
+from fegrow.cli.utils import Settings
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(score)
+
+
+@cli.command()
+@click.option(
+    "-g",
+    "--gnina-path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, executable=True),
+    help="The path to the gnina executable which will override the settings.",
+)
+def settings(gnina_path: pathlib.Path):
+    """
+    Create a runtime settings object for scoring runs which can be configured.
+    """
+    config = Settings(gnina_path=gnina_path)
+    with open("settings.json") as output:
+        output.write(config.json(indent=2))
+

--- a/fegrow/cli/scoring.py
+++ b/fegrow/cli/scoring.py
@@ -1,0 +1,133 @@
+import pathlib
+import time
+
+import click
+from typing import Optional
+
+
+@click.command()
+@click.option(
+    "-c",
+    "--core-ligand",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="The path to the SDF file of the core ligand which will be used to restrain the geometries of the scored ligands this should be a substructure of the ligands to be scored.",
+)
+@click.option(
+    "-l" "--ligands",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="The path to the ligands to be scored can be in any supported format by RDKit such as csv. smiles or SDF.",
+)
+@click.option(
+    "-r",
+    "--receptor",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="The path of the receptor PDB file, this should only contain the receptor and not the reference ligand.",
+)
+@click.option(
+    "-s",
+    "--settings",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="The path of the settings file which configures the scoring run.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(dir_okay=True),
+    help="The name of the output folder.",
+)
+@click.option(
+    "-g",
+    "--gnina-path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, executable=True),
+    help="The path to the gnina executable which will override the settings.",
+)
+def score(
+    core_ligand: pathlib.Path,
+    ligands: pathlib.Path,
+    receptor: pathlib.Path,
+    output: pathlib.Path,
+    settings: Optional[pathlib.Path] = None,
+    gnina_path: Optional[pathlib.Path] = None,
+):
+    """
+    Score the list of input ligands using Gnina after optimising in the receptor.
+    """
+    from dask.distributed import Client
+    from rdkit import Chem
+    import traceback
+    import dask
+    import tqdm
+
+    from fegrow.cli.utils import score_ligand, Settings, load_target_ligands
+
+    try:
+        from mycluster import create_cluster
+    except ImportError:
+
+        def create_cluster():
+            from dask.distributed import LocalCluster
+
+            return LocalCluster()
+
+    client = Client(create_cluster())
+    # create the cluster
+    click.echo(f"Client created {client}")
+
+    if settings is not None:
+        config = Settings.parse_file(settings)
+        if gnina_path is not None:
+            config.gnina_path = gnina_path
+    else:
+        # build the base settings object this needs the gnina path
+        config = Settings(gnina_path=gnina_path)
+
+    click.echo(f"Loading core ligand from {core_ligand}")
+    # we remove all Hs rather than specific ones at the attachment point
+    core = Chem.MolFromMolFile(core_ligand, removeHs=True)
+    core_dask = dask.delayed(core)
+
+    # load the target ligands
+    target_smiles = load_target_ligands(ligand_file=ligands)
+
+    # build a list of tasks to submit
+    for_submission = [
+        score_ligand(
+            core_ligand=core_dask,
+            target_smiles=smiles,
+            receptor=receptor,
+            settings=config,
+        )
+        for smiles in target_smiles
+    ]
+
+    submitted = client.compute(for_submission)
+    jobs = dict((job, i) for i, job in enumerate(submitted))
+
+    output_path = pathlib.Path(output)
+    output_path.mkdir(exist_ok=True)
+
+    molecule_output = Chem.SDWriter(output_path.joinpath("scored_molecules.sdf"))
+    with tqdm.tqdm(total=len(submitted), desc="Scoring molecules...", ncols=80) as pbar:
+        while len(jobs) > 0:
+            for job, index in jobs.items():
+                if not job.done():
+                    continue
+
+                # remove the job
+                del jobs[job]
+                pbar.update(1)
+
+                try:
+                    mol_data = job.result()
+                    rmol = mol_data.pop("molecule")
+                    # recover the properties (they are not passed with serialisation)
+                    [rmol.SetProp(k, str(v)) for k, v in mol_data.items()]
+                    # write the molecule out when they complete incase we crash
+                    molecule_output.write(rmol)
+                except Exception as E:
+                    print("error for index, ", index)
+                    traceback.print_exc()
+
+            time.sleep(5)
+
+    click.echo("All molecules scored")

--- a/fegrow/cli/utils.py
+++ b/fegrow/cli/utils.py
@@ -1,0 +1,136 @@
+import dask
+from rdkit import Chem
+from pydantic import BaseModel, Field
+from typing import Optional
+from fegrow.receptor import ForceField
+from fegrow import RMol
+import pathlib
+import pandas as pd
+from rdkit.Chem import PandasTools
+
+
+class Settings(BaseModel):
+    """A class to configure the runtime settings of a high throughput scoring."""
+
+    num_confs: int = Field(
+        50,
+        description="The number of initial conformers which should be generated using RDKit.",
+    )
+    conf_rms: float = Field(
+        0.2,
+        description="The rms cutoff in angstrom for which two conformers are considered the same. Used while generating the conformations.",
+    )
+    ligand_force_field: ForceField = Field(
+        "openff",
+        description="The force field model to use for the small molecule during the restrained optimisation.",
+    )
+    use_ani: bool = Field(
+        True,
+        description="If we should attempt to use ANI2x to model the internal energies of the ligand in an ML/MM optimisation.",
+    )
+    sigma_scale_factor: float = Field(
+        0.8,
+        description="The amount the sigma of the force field should be scaled by to compensate for the rigid recptor.",
+    )
+    relative_permittivity: float = Field(
+        4,
+        description="The relative permittivity which should be used to scale the charge interactions of the system to mimic a condensed phase environment.",
+    )
+    water_model: Optional[str] = Field(
+        None,
+        description="The name of the water force field model from openmmforcefields which should be used, eg tip3p.xml",
+    )
+    platform_name: str = Field(
+        "CPU",
+        description="The name of the OpenMM platform which should be used during the geometry optimisation",
+    )
+    gnina_path: str = Field(
+        ...,
+        description="The path to the gnina executable which should be used to score the ligands.",
+    )
+    energy_filter: float = Field(
+        2,
+        description="The relative energy cutoff in kcal/mol used to select the top conformers for scoring.",
+    )
+
+
+@dask.delayed
+def score_ligand(
+    core_ligand: Chem.Mol,
+    target_smiles: str,
+    receptor: pathlib.Path,
+    settings: Settings,
+) -> dict:
+    """
+    Score the ligand given by the target smiles using the core ligand to restrain the geometry.
+
+    Note:
+        We assume the core does not need to be altered and is a substructure of the target ligand
+    """
+    # create the target ligand with Hs
+    candidate_mol = Chem.MolFromSmiles(target_smiles)
+    candidate_mol = Chem.AddHs(candidate_mol)
+    rmol = RMol(candidate_mol)
+    # set up the core as the template
+    rmol._save_template(core_ligand)
+
+    # conformer gen
+    rmol.generate_conformers(
+        num_conf=settings.num_confs, minimum_conf_rms=settings.conf_rms
+    )
+    # remove missing
+    rmol.remove_clashing_confs(protein=receptor.as_posix())
+
+    # optimise
+    rmol.optimise_in_receptor(
+        receptor_file=receptor,
+        ligand_force_field=settings.ligand_force_field,
+        use_ani=settings.use_ani,
+        sigma_scale_factor=settings.sigma_scale_factor,
+        relative_permittivity=settings.relative_permittivity,
+        water_model=settings.water_model,
+        platform_name=settings.platform_name,
+    )
+
+    if rmol.GetNumConformers() == 0:
+        # set a pentalty
+        cnnaffinity = 0
+        cnnaffinityIC50 = 0
+    else:
+        # score only the lowest energy conformer
+        rmol.sort_conformers(energy_range=settings.energy_filter)  # kcal/mol
+        # purge all but the lowest energy conformers
+        rmol = Rmol(rmol, confId=0)
+        affinities = rmol.gnina(receptor_file=receptor.as_posix())
+        cnnaffinity = -affinities.CNNaffinity.values[0]
+        cnnaffinityIC50 = affinities["CNNaffinity->IC50s"].values[0]
+
+    data = {
+        "cnnaffinity": cnnaffinity,
+        "cnnaffinityIC50": cnnaffinityIC50,
+        "molecule": rmol,
+    }
+
+    return data
+
+
+def load_target_ligands(ligand_file: pathlib.Path) -> list[str]:
+    """
+    Load a set of ligands from any RDKit supported file format.
+
+    Note:
+        For CSV we assume that the smiles have the column name "Smiles"
+    """
+    if ligand_file.stem.lower == "csv":
+        target_molecules = pd.read_csv(ligand_file)
+        return list(target_molecules.Smiles.values)
+
+    if ligand_file.stem.lower() in ["sdf", "mol"]:
+        ligands = list(Chem.SDMolSupplier(ligand_file, removeHs=False))
+    elif ligand_file.stem.lower() == "smi":
+        ligands = list(Chem.SmilesMolSupplier(ligand_file, remoeHs=False))
+    else:
+        raise RuntimeError(f"Can extract smiles from input file {ligand_file}")
+
+    smiles = [Chem.MolToSmiles(mol) for mol in ligands]
+    return smiles

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,6 @@ python_requires = >=3.7
 install_requires =
 [options.packages.find]
 where =
+[options.entry_points]
+console_scripts =
+    fegrow = fegrow.cli.cli:cli


### PR DESCRIPTION
This PR adds a simple CLI to fegrow allowing users to grow and score a large selection of molecules via dask. This works slightly differently to the normal notebook pathway in that a core must be provided along with a list of molecules for which the core is a substructure rather than providing a core and groups to attach.

To create a settings object which gives detailed control over the workflow run
```bash
fegrow settings -g <path-to-gnina>
```
This will create a `settings.json` file which can be edited, note that the path to the gnina executable must be passed as this is blank by default.

To then run the workflow use
```bash
fegrow score -c core_ligand.sdf -l target_ligands.smi -r receptor.pdb -s settings.json -o scored_mols
```
