### PR TITLE
Energy minimisation for any single conformer is now allowed to fail

### DIFF
--- a/fegrow/receptor.py
+++ b/fegrow/receptor.py
@@ -25,7 +25,7 @@ from openff.toolkit.topology import Molecule as OFFMolecule
 logger = logging.getLogger(__name__)
 
 
-class NoPostMinimisationConformers(Exception):
+class NoPostMinimisationConformersError(Exception):
     """Raise if no conformers survive minimisation (due to e.g. simulation blowing up)"""
 
 
@@ -252,7 +252,7 @@ def optimise_in_receptor(
         final_mol.AddConformer(final_conformer, assignId=True)
 
     if final_mol.GetNumConformers() == 0:
-        raise NoPostMinimisationConformers()
+        raise NoPostMinimisationConformersError()
 
     return final_mol, energies
 


### PR DESCRIPTION
Occasionally a conformer is generated that leads to NaN in OpenMM. Even though other conformers are fine, the pipeline fails. Now a log warning is provided instead. 

If all conformers fail, a molecule without conformers is returned. 